### PR TITLE
Adds managementUrl param to CustomerInfo and appUserId config function

### DIFF
--- a/kmprevenuecat-purchases/src/androidMain/kotlin/com/mmk/kmprevenuecat/purchases/Mapper.android.kt
+++ b/kmprevenuecat-purchases/src/androidMain/kotlin/com/mmk/kmprevenuecat/purchases/Mapper.android.kt
@@ -75,6 +75,7 @@ internal fun RevenueCatEntitlementInfo.asEntitlementInfo(): EntitlementInfo {
 public fun RevenueCatCustomerInfo.asCustomerInfo(): CustomerInfo {
     return CustomerInfo(
         originalAppUserId = this.originalAppUserId,
-        entitlements = entitlements.asEntitlementInfos()
+        entitlements = entitlements.asEntitlementInfos(),
+        managementURL = managementURL.toString()
     )
 }

--- a/kmprevenuecat-purchases/src/androidMain/kotlin/com/mmk/kmprevenuecat/purchases/PurchasesImpl.kt
+++ b/kmprevenuecat-purchases/src/androidMain/kotlin/com/mmk/kmprevenuecat/purchases/PurchasesImpl.kt
@@ -3,17 +3,10 @@ package com.mmk.kmprevenuecat.purchases
 import android.content.Context
 import com.mmk.kmprevenuecat.purchases.data.CustomerInfo
 import com.mmk.kmprevenuecat.purchases.data.LogInResult
-import com.revenuecat.purchases.CustomerInfo as RevenueCatCustomerInfo
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.PurchasesException
-import com.revenuecat.purchases.awaitCustomerInfo
-import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
-import java.util.jar.Attributes
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
+import com.revenuecat.purchases.CustomerInfo as RevenueCatCustomerInfo
 import com.revenuecat.purchases.Purchases as RevenueCatPurchases
 import com.revenuecat.purchases.interfaces.LogInCallback as RevenueCatLoginCallback
 
@@ -24,8 +17,12 @@ internal class PurchasesImpl(private val context: Context) : Purchases {
             RevenueCatPurchases.logLevel = value.asRevenueCatLogLevel()
         }
 
-    override fun configure(apiKey: String) {
-        RevenueCatPurchases.configure(PurchasesConfiguration.Builder(context, apiKey).build())
+    override fun configure(apiKey: String, appUserId: String?) {
+        RevenueCatPurchases.configure(
+            PurchasesConfiguration.Builder(context, apiKey)
+                .appUserID(appUserId)
+                .build()
+        )
     }
 
     @OptIn(KMPRevenueCatInternalApi::class)
@@ -73,7 +70,7 @@ internal class PurchasesImpl(private val context: Context) : Purchases {
             })
     }
 
-    override fun setAttributes(attributes: Map<String,String?>){
+    override fun setAttributes(attributes: Map<String, String?>) {
         RevenueCatPurchases.sharedInstance.setAttributes(attributes)
     }
 

--- a/kmprevenuecat-purchases/src/commonMain/kotlin/com/mmk/kmprevenuecat/purchases/Purchases.kt
+++ b/kmprevenuecat-purchases/src/commonMain/kotlin/com/mmk/kmprevenuecat/purchases/Purchases.kt
@@ -11,7 +11,7 @@ public interface Purchases {
 
     public var logLevel: LogLevel
 
-    public fun configure(apiKey: String)
+    public fun configure(apiKey: String, appUserId: String? = null)
 
     public fun login(appUserId: String, onResult: (Result<LogInResult>) -> Unit)
     public fun logOut(onResult: (Result<CustomerInfo>) -> Unit)

--- a/kmprevenuecat-purchases/src/commonMain/kotlin/com/mmk/kmprevenuecat/purchases/data/CustomerInfo.kt
+++ b/kmprevenuecat-purchases/src/commonMain/kotlin/com/mmk/kmprevenuecat/purchases/data/CustomerInfo.kt
@@ -2,5 +2,6 @@ package com.mmk.kmprevenuecat.purchases.data
 
 public data class CustomerInfo(
     val originalAppUserId: String,
-    val entitlements: EntitlementInfos
+    val entitlements: EntitlementInfos,
+    val managementURL: String?
 ) 

--- a/kmprevenuecat-purchases/src/iosMain/kotlin/com/mmk/kmprevenuecat/purchases/Mapper.ios.kt
+++ b/kmprevenuecat-purchases/src/iosMain/kotlin/com/mmk/kmprevenuecat/purchases/Mapper.ios.kt
@@ -100,7 +100,8 @@ internal fun RCEntitlementInfo.asEntitlementInfo(): EntitlementInfo {
 public fun RCCustomerInfo.asCustomerInfo(): CustomerInfo {
     return CustomerInfo(
         originalAppUserId = originalAppUserId(),
-        entitlements = entitlements().asEntitlementInfos()
+        entitlements = entitlements().asEntitlementInfos(),
+        managementURL = managementURL().toString()
     )
 }
 

--- a/kmprevenuecat-purchases/src/iosMain/kotlin/com/mmk/kmprevenuecat/purchases/PurchasesImpl.kt
+++ b/kmprevenuecat-purchases/src/iosMain/kotlin/com/mmk/kmprevenuecat/purchases/PurchasesImpl.kt
@@ -5,9 +5,6 @@ import cocoapods.RevenueCat.configureWithAPIKey
 import com.mmk.kmprevenuecat.purchases.data.CustomerInfo
 import com.mmk.kmprevenuecat.purchases.data.LogInResult
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 
 
 @OptIn(ExperimentalForeignApi::class)
@@ -18,8 +15,8 @@ internal class PurchasesImpl : Purchases {
             RCPurchases.setLogLevel(value.asRevenueCatLogLevel())
         }
 
-    override fun configure(apiKey: String) {
-        RCPurchases.configureWithAPIKey(apiKey)
+    override fun configure(apiKey: String, appUserId: String?) {
+        RCPurchases.configureWithAPIKey(apiKey, appUserId)
     }
 
     @OptIn(KMPRevenueCatInternalApi::class)


### PR DESCRIPTION
The managementUrl param is mostly for convenience and API coverage.

The appUserId overload is used to avoid using anonymous RevenueCat IDs. See [documentation](https://www.revenuecat.com/docs/customers/user-ids#how-to-only-use-custom-app-user-ids) for more information.